### PR TITLE
Made Geocoder reference a config key more in line with the locator

### DIFF
--- a/code/GoogleGeocoder.php
+++ b/code/GoogleGeocoder.php
@@ -34,7 +34,7 @@ class GoogleGeocoder
             null,
             null,
             true,
-            Config::inst()->get('SilverStripeGeocoder', 'geocoder_api_key')
+            Config::inst()->get(GoogleGeocoder::class, 'geocoder_api_key')
         );
 
         $this->setClient($geocoder);


### PR DESCRIPTION
  - Uses GoogleGeocoder::class instead of SilverStripeGeocoder