### PR TITLE
fix: don't pass null to `strtoupper` as its deprecated in PHP 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 SilverStripe wrapper for [Geocoder](https://github.com/geocoder-php/Geocoder)
 
-[![Build Status](https://travis-ci.org/dynamic/silverstripe-geocoder.svg?branch=master)](https://travis-ci.org/dynamic/silverstripe-geocoder)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/dynamic/silverstripe-geocoder/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/dynamic/silverstripe-geocoder/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/dynamic/silverstripe-geocoder/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/dynamic/silverstripe-geocoder/?branch=master)
-[![Build Status](https://scrutinizer-ci.com/g/dynamic/silverstripe-geocoder/badges/build.png?b=master)](https://scrutinizer-ci.com/g/dynamic/silverstripe-geocoder/build-status/master)
+[![CI](https://github.com/dynamic/silverstripe-geocoder/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-geocoder/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/dynamic/silverstripe-geocoder/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-geocoder)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-geocoder/v/stable)](https://packagist.org/packages/dynamic/silverstripe-geocoder)
@@ -15,7 +12,9 @@ SilverStripe wrapper for [Geocoder](https://github.com/geocoder-php/Geocoder)
 
 ## Requirements
 
-- SilverStripe 4.0
+- SilverStripe ^4.0
+- dynamic/silverstripe-country-dropdown-field ^1.0
+- willdurand/geocoder ^4.0
 
 ## Installation
 
@@ -37,6 +36,7 @@ SilverStripe\ORM\DataObject:
 
 Dynamic\SilverStripeGeocoder\GoogleGeocoder:
   geocoder_api_key: 'your-key-here'
+  map_api_key: 'your-key-here'
 ```
 
 ## Documentation
@@ -63,7 +63,7 @@ Using `$AddressMap` in a template will render the map.
 `$AddressMap` also has options to easily modify the width, height, and scale of the map. `$AddressMap(320, 240, 1)`
 
 ##### Map Style
-The map can be styled by adding a `mapStyle.json` in any of the following folders in a theme: 
+The map can be styled by adding a `mapStyle.json` in any of the following folders in a theme:
 ```
 client/dist/js/
 client/dist/javascript/
@@ -79,7 +79,7 @@ styles can be generated using an online service like [Styling Wizard: Google Map
 **This does not work on local due to google needing to download the image off the server.**
 
 A custom marker image can be used to match the style of the map in about the same way as the style.
-An image named `mapIcon` with an extension of `png`, `jpg`, `jpeg`, or `gif` can be put in any of the following folders in a theme: 
+An image named `mapIcon` with an extension of `png`, `jpg`, `jpeg`, or `gif` can be put in any of the following folders in a theme:
 ```
 client/dist/img/
 client/dist/images/
@@ -90,7 +90,7 @@ images/
 ```
 
 ### DistanceDataExtension
-The DistanceDataExtension should be used in conjunction with the AddressDataExtension. 
+The DistanceDataExtension should be used in conjunction with the AddressDataExtension.
 The only time it is viable by itself is if the extended DataObject has `Lat` and `Lng` fields.
 
 The DistanceDataExtension will add a pseudo field for distance away from an address to a DataObject.
@@ -110,20 +110,20 @@ See the [docs/en](docs/en/index.md) folder.
 
 ## Maintainers
  *  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)
- 
+
 ## Bugtracker
-Bugs are tracked in the issues section of this repository. Before submitting an issue please read over 
-existing issues to ensure yours is unique. 
- 
+Bugs are tracked in the issues section of this repository. Before submitting an issue please read over
+existing issues to ensure yours is unique.
+
 If the issue does look like a new bug:
- 
+
  - Create a new issue
- - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots 
+ - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots
  and screencasts can help here.
- - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version, 
+ - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version,
  Operating System, any installed SilverStripe modules.
- 
+
 Please report security issues to the module maintainers directly. Please don't file security issues in the bugtracker.
- 
+
 ## Development and contribution
 If you would like to make contributions to the module please ensure you raise a pull request and discuss with the module maintainers.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "dynamic/silverstripe-country-dropdown-field": "^1.0",
-        "willdurand/geocoder": "^4.0"
+        "geocoder-php/google-maps-provider": "^4.7",
+        "guzzlehttp/guzzle": "^7.4",
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^2",
@@ -37,11 +39,6 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        }
-    },
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"

--- a/src/AddressDataExtension.php
+++ b/src/AddressDataExtension.php
@@ -297,8 +297,10 @@ class AddressDataExtension extends DataExtension
             if ($address = $this->getFullAddress()) {
                 $geocoder = new GoogleGeocoder($address);
                 $response = $geocoder->getResult();
-                $this->owner->Lat = $response->getLatitude();
-                $this->owner->Lng = $response->getLongitude();
+                $dumper = new \Geocoder\Dumper\GeoArray();
+                $result = $dumper->dump($response);
+                $this->owner->Lat = $result['geometry']['coordinates'][0];
+                $this->owner->Lng = $result['geometry']['coordinates'][1];
             }
         }
     }

--- a/src/AddressDataExtension.php
+++ b/src/AddressDataExtension.php
@@ -94,8 +94,11 @@ class AddressDataExtension extends DataExtension
             $this->owner->City,
             $this->owner->State,
             $this->owner->PostalCode,
-            strtoupper($this->owner->Country),
         ];
+        
+        if ($this->owner->Country !== null) {
+            $parts[] = strtoupper($this->owner->Country);
+        }
 
         return implode(', ', array_filter($parts));
     }

--- a/src/DistanceDataExtension.php
+++ b/src/DistanceDataExtension.php
@@ -35,8 +35,10 @@ class DistanceDataExtension extends DataExtension
         if ($address) { // on frontend
             $geocoder = new GoogleGeocoder($address);
             $response = $geocoder->getResult();
-            $Lat = $response->getLatitude();
-            $Lng = $response->getLongitude();
+            $dumper = new \Geocoder\Dumper\GeoArray();
+            $result = $dumper->dump($response);
+            $Lat = $this->owner->Lat = $result['geometry']['coordinates'][0];
+            $Lng = $this->owner->Lng = $result['geometry']['coordinates'][1];
 
             $query
                 ->addSelect(array(

--- a/src/GeocoderAdapter.php
+++ b/src/GeocoderAdapter.php
@@ -22,7 +22,7 @@ class GeocoderAdapter
     public function __construct($adapter = null)
     {
         if ($adapter === null) {
-            $adapter = new CurlHttpAdapter();
+            $adapter = new \GuzzleHttp\Client();
         }
         $this->setAdapter($adapter);
     }

--- a/src/GoogleGeocoder.php
+++ b/src/GoogleGeocoder.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\SilverStripeGeocoder;
 
-use \Geocoder\Provider\GoogleMaps;
+use Geocoder\Provider\GoogleMaps\GoogleMaps;
 use \SilverStripe\Core\Config\Config;
 
 /**
@@ -27,15 +27,14 @@ class GoogleGeocoder
      */
     public function __construct($address)
     {
-        $adapter  = new GeocoderAdapter();
-        $adapter = $adapter->getAdapter();
-        $geocoder = new GoogleMaps(
-            $adapter,
+        $httpClient  = new GeocoderAdapter();
+        $httpClient = $httpClient->getAdapter();
+        $provider = new \Geocoder\Provider\GoogleMaps\GoogleMaps(
+            $httpClient,
             null,
-            null,
-            true,
             Config::inst()->get(GoogleGeocoder::class, 'geocoder_api_key')
         );
+        $geocoder = new \Geocoder\StatefulGeocoder($provider, 'en');
 
         $this->setClient($geocoder);
         $this->setResults($address);


### PR DESCRIPTION
It would be awesome if this could be landed into v1.x as it looks like the only stopper to moving to PHP 8.1 for us, and I don't know if/when parent packages will upgrade to use v2 of this library 🙏 