### PR TITLE
Fix for issue #64

### DIFF
--- a/src/AddressDataExtension.php
+++ b/src/AddressDataExtension.php
@@ -299,7 +299,7 @@ class AddressDataExtension extends DataExtension
             }
             if ($address = $this->getFullAddress()) {
                 $geocoder = new GoogleGeocoder($address);
-                $response = $geocoder->getResult();                
+                $response = $geocoder->getResult();
                 $this->owner->Lat = $response->getCoordinates()->getLatitude();
                 $this->owner->Lng = $response->getCoordinates()->getLongitude();
             }

--- a/src/AddressDataExtension.php
+++ b/src/AddressDataExtension.php
@@ -299,11 +299,9 @@ class AddressDataExtension extends DataExtension
             }
             if ($address = $this->getFullAddress()) {
                 $geocoder = new GoogleGeocoder($address);
-                $response = $geocoder->getResult();
-                $dumper = new \Geocoder\Dumper\GeoArray();
-                $result = $dumper->dump($response);
-                $this->owner->Lat = $result['geometry']['coordinates'][0];
-                $this->owner->Lng = $result['geometry']['coordinates'][1];
+                $response = $geocoder->getResult();                
+                $this->owner->Lat = $response->getCoordinates()->getLatitude();
+                $this->owner->Lng = $response->getCoordinates()->getLongitude();
             }
         }
     }


### PR DESCRIPTION
Currently it looks like geocoder when looking at the raw result for coordinates may return the lat/longitude in random order.  This method uses the geocoders default methods for getting the latitude and longitude which will then store the proper values.