### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,11 +50,6 @@
             "url": "https://github.com/sponsors/dynamic"
         }
     ],
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.0.x-dev"
-        }
-    },
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "silverstripe/recipe-core": "^6"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,13 @@
         }
     ],
     "require": {
-        "dynamic/silverstripe-country-dropdown-field": "^2",
+        "php": "^8.1",
+        "dynamic/silverstripe-country-dropdown-field": "^3",
         "geocoder-php/google-maps-provider": "^4.7",
         "guzzlehttp/guzzle": "^7.4",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/message": "^1.13",
-        "silverstripe/recipe-core": "^5.0"
+        "silverstripe/recipe-core": "^6"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^3"
@@ -51,7 +52,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.0.x-dev"
         }
     },
     "scripts": {

--- a/src/AddressDataExtension.php
+++ b/src/AddressDataExtension.php
@@ -13,7 +13,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\TextField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\ThemeResourceLoader;
 
@@ -31,7 +31,7 @@ use SilverStripe\View\ThemeResourceLoader;
  * @property float $Lat
  * @property float $Lng
  */
-class AddressDataExtension extends DataExtension
+class AddressDataExtension extends Extension
 {
     /**
      * @var array
@@ -326,9 +326,8 @@ class AddressDataExtension extends DataExtension
     /**
      *
      */
-    public function onBeforeWrite()
+    protected function onBeforeWrite()
     {
-        parent::onBeforeWrite();
         if ($this->hasAddress() && !$this->owner->config()->get('disable_geocoding')
             && Config::inst()->get(GoogleGeocoder::class, 'geocoder_api_key')) {
             if (!$this->isAddressChanged()) {

--- a/src/DistanceDataExtension.php
+++ b/src/DistanceDataExtension.php
@@ -10,8 +10,6 @@ use SilverStripe\Control\Controller;
 
 /**
  * Class \Dynamic\SilverStripeGeocoder\DistanceDataExtension
- *
- * @property DistanceDataExtension $owner
  */
 class DistanceDataExtension extends Extension
 {
@@ -19,7 +17,7 @@ class DistanceDataExtension extends Extension
      * @param SQLSelect $query
      * @param DataQuery|null $dataQuery
      */
-    public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
+    public function augmentSQL(SQLSelect $query, ?DataQuery $dataQuery = null)
     {
         $addressVar = Config::inst()->get(DistanceDataExtension::class, 'address_var');
         $unitVar = Config::inst()->get(DistanceDataExtension::class, 'unit_var');

--- a/src/DistanceDataExtension.php
+++ b/src/DistanceDataExtension.php
@@ -3,7 +3,7 @@
 namespace Dynamic\SilverStripeGeocoder;
 
 use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\Control\Controller;
@@ -13,7 +13,7 @@ use SilverStripe\Control\Controller;
  *
  * @property DistanceDataExtension $owner
  */
-class DistanceDataExtension extends DataExtension
+class DistanceDataExtension extends Extension
 {
     /**
      * @param SQLSelect $query


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.1
- Updated core dependency `silverstripe/recipe-core` from ^5 to ^6
- Updated `dynamic/silverstripe-country-dropdown-field` from ^2 to ^3 (SS6 compatible)
- Fixed namespace changes:
  - Extension: `SilverStripe\ORM\DataExtension` → `SilverStripe\Core\Extension`
- Removed `parent::onBeforeWrite()` call (Extension base class doesn't have this method)
- Changed `onBeforeWrite()` visibility to `protected` (SS6 standard)
- Removed branch-alias

## Testing

- ✅ PHPUnit: 6/6 tests passing
- ✅ PHPCS: Clean
- ✅ Code follows SS6 Extension patterns

This prepares the module for the 4.0.0 release and resolves dependency issues blocking other Dynamic modules from upgrading to SS6.