### PR TITLE
docs: Update README for SilverStripe 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SilverStripe wrapper for [Geocoder](https://github.com/geocoder-php/Geocoder)
 ## Requirements
 
 - PHP: ^8.3
-- SilverStripe: ^6
+- silverstripe/recipe-core: ^6
 - dynamic/silverstripe-country-dropdown-field: ^3
 - geocoder-php/google-maps-provider: ^4.7
 - guzzlehttp/guzzle: ^7.4
@@ -136,9 +136,9 @@ SilverStripe Geocoder v4.0 is compatible with SilverStripe 6. Key changes:
 - Updated to SilverStripe CMS 6
 - Requires PHP 8.3 or higher
 - Updated `dynamic/silverstripe-country-dropdown-field` from ^2 to ^3 (SS6 compatible)
-- Extension namespace changes (ORM → Core\Extension)
+- Internal extension namespace changes (ORM → Core\Extension); no changes required in user code
 
-See the [SilverStripe 6 Upgrade Guide](https://docs.silverstripe.org/en/6/) for more details.
+For details on the SilverStripe 6 upgrade, see the [SilverStripe 6 upgrade guide](https://docs.silverstripe.org/en/6/changelogs/6.0.0/).
 
 ## Maintainers
  *  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)

--- a/README.md
+++ b/README.md
@@ -3,26 +3,34 @@
 SilverStripe wrapper for [Geocoder](https://github.com/geocoder-php/Geocoder)
 
 [![CI](https://github.com/dynamic/silverstripe-geocoder/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-geocoder/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-geocoder/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-geocoder)
-[![Sponsor](https://img.shields.io/badge/Sponsor-Dynamic-brightgreen)](https://github.com/sponsors/dynamic)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/dynamic?label=Sponsors&logo=GitHub%20Sponsors&style=flat&color=ea4aaa)](https://github.com/sponsors/dynamic)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-geocoder/v/stable)](https://packagist.org/packages/dynamic/silverstripe-geocoder)
 [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-geocoder/downloads)](https://packagist.org/packages/dynamic/silverstripe-geocoder)
-[![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-geocoder/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-geocoder)
 [![License](https://poser.pugx.org/dynamic/silverstripe-geocoder/license)](https://packagist.org/packages/dynamic/silverstripe-geocoder)
 
 ## Requirements
 
-- Silverstripe ^5
-- dynamic/silverstripe-country-dropdown-field ^2
-- geocoder-php/google-maps-provider ^4.7
-- guzzlehttp/guzzle ^7.4
-- php-http/guzzle7-adapter ^1.0
-- php-http/message ^1.13
+- PHP: ^8.3
+- SilverStripe: ^6
+- dynamic/silverstripe-country-dropdown-field: ^3
+- geocoder-php/google-maps-provider: ^4.7
+- guzzlehttp/guzzle: ^7.4
+- php-http/guzzle7-adapter: ^1.0
+- php-http/message: ^1.13
 
 ## Installation
 
 `composer require dynamic/silverstripe-geocoder`
+
+## Features
+
+- **Address Geocoding**: Automatically convert addresses to latitude/longitude coordinates using Google Maps Geocoding API
+- **Address Data Extension**: Adds comprehensive address fields (Address, City, State, PostalCode, Country, Lat, Lng) to any DataObject
+- **Distance Calculation**: Calculate and filter DataObjects by distance from a given address
+- **Static Map Generation**: Generate static Google Maps images with custom styling and markers
+- **Country Dropdown Integration**: Includes country selection field with international support
+- **Flexible Configuration**: Disable geocoding per DataObject, customize map styles, and use custom marker icons
 
 ## License
 
@@ -120,6 +128,17 @@ public function updateAddressValue(&$address) {
     $address = 'Neuschwansteinstraße 20, 87645 Schwangau, Germany';
 }
 ```
+
+## Upgrading from version 3
+
+SilverStripe Geocoder v4.0 is compatible with SilverStripe 6. Key changes:
+
+- Updated to SilverStripe CMS 6
+- Requires PHP 8.3 or higher
+- Updated `dynamic/silverstripe-country-dropdown-field` from ^2 to ^3 (SS6 compatible)
+- Extension namespace changes (ORM → Core\Extension)
+
+See the [SilverStripe 6 Upgrade Guide](https://docs.silverstripe.org/en/6/) for more details.
 
 ## Maintainers
  *  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "dynamic/silverstripe-country-dropdown-field": "^3",
         "geocoder-php/google-maps-provider": "^4.7",
         "guzzlehttp/guzzle": "^7.4",


### PR DESCRIPTION
Updates README documentation for the SilverStripe 6 release.

## Changes

- Updated PHP requirement to ^8.3 (SilverStripe 6 requirement)
- Updated all dependencies to SS6 compatible versions in Requirements section
- Added GitHub Sponsors badge (replacing codecov)
- Removed unstable version badge
- Added comprehensive Features section highlighting 6 key capabilities:
  - Address Geocoding with Google Maps API
  - Address Data Extension
  - Distance Calculation
  - Static Map Generation
  - Country Dropdown Integration
  - Flexible Configuration
- Added upgrade notes for v3→v4 transition
- Added SilverStripe 6 upgrade guide reference

This completes the documentation updates for the v4.0 release.